### PR TITLE
mirrored action events in hyper_events

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 dist/
 *.js
+*.html
 
 LICENSE
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The `SuperAction` below listens for `click` events. Event listeners are immediat
 ```js
 import { SuperAction } from "superaction";
 
-const superAction = new SuperAction({
-	host: document,
+const _superAction = new SuperAction({
+	target: document,
 	connected: true,
 	eventNames: ["click"],
 });
@@ -30,15 +30,15 @@ Add an attribute with the pattern `_event=action`. The `#action` event will _alw
 the element with the `_event` attribute.
 
 ```html
-<button _click="decrement">-</button>
-<button _click="increment">+</button>
+<button click:="decrement">-</button>
+<button click:="increment">+</button>
 ```
 
 ## Listen
 
 ```js
 addEventListener("#action", (e) => {
-	let { action } = e;
+	let { action, sourceEvent } = e.actionParams;
 
 	if ("decrement" === action) {
 		// decrement something!
@@ -55,11 +55,11 @@ addEventListener("#action", (e) => {
 I'm not trying to pollute your globals so if you want typed `#action` events, please add the following to your app somewhere thoughtful.
 
 ```ts
-import { SuperActionEvent } from "superaction";
+import type { ActionEventInterface } from "superaction";
 
 declare global {
 	interface GlobalEventHandlersEventMap {
-		["#action"]: SuperActionEvent;
+		["#action"]: ActionEventInterface;
 	}
 }
 ```

--- a/dist/mod.d.ts
+++ b/dist/mod.d.ts
@@ -1,27 +1,28 @@
-export type { SuperActionParamsInterface, SuperActionEventInterface, SuperActionInterface, };
-export { SuperActionEvent, SuperAction };
-interface SuperActionParamsInterface {
-    host: ParentNode;
+export interface ActionInterface {
+    sourceEvent: Event;
+    action: string;
+    formData?: FormData;
+}
+export interface ActionEventInterface extends Event {
+    actionParams: ActionInterface;
+}
+export interface SuperActionParamsInterface {
+    target: ParentNode;
     eventNames: string[];
     connected?: boolean;
 }
-interface SuperActionInterface {
+export interface SuperActionInterface {
     connect(): void;
     disconnect(): void;
 }
-interface SuperActionEventInterface extends Event {
-    action: string;
-    sourceEvent: Event;
+export declare class ActionEvent extends Event implements ActionEventInterface {
+    actionParams: ActionInterface;
+    constructor(actionParams: ActionInterface, eventInit?: EventInit);
 }
-declare class SuperAction {
+export declare class SuperAction implements SuperActionInterface {
     #private;
     constructor(params: SuperActionParamsInterface);
     connect(): void;
     disconnect(): void;
 }
-declare class SuperActionEvent extends Event implements SuperActionEvent {
-    #private;
-    constructor(action: string, sourceEvent: Event);
-    get action(): string;
-    get sourceEvent(): Event;
-}
+export declare function dispatch(sourceEvent: Event): void;

--- a/dist/mod.js
+++ b/dist/mod.js
@@ -29,43 +29,23 @@ export function dispatch(sourceEvent) {
     let { type, currentTarget, target } = sourceEvent;
     if (!currentTarget)
         return;
-    // I forget if a formdata element can be reused but important to find out
     let formData;
     if (target instanceof HTMLFormElement)
         formData = new FormData(target);
     for (let node of sourceEvent.composedPath()) {
         if (node instanceof Element) {
-            let kind = node.getAttribute(`${type}:`);
-            if (!kind)
+            let action = node.getAttribute(`${type}:`);
+            if (!action)
                 continue;
             if (node.hasAttribute(`${type}:prevent-default`))
                 sourceEvent.preventDefault();
             if (node.hasAttribute(`${type}:stop-immediate-propagation`))
                 return;
             let composed = node.hasAttribute(`${type}:composed`);
-            dispatchActionEvent({
-                el: node,
-                sourceEvent,
-                composed,
-                formData,
-            });
+            let event = new ActionEvent({ action, sourceEvent, formData }, { bubbles: true, composed });
+            node.dispatchEvent(event);
             if (node.hasAttribute(`${type}:stop-propagation`))
                 return;
         }
     }
-}
-function dispatchActionEvent(dispatchParams) {
-    let actionParams = getActionParams(dispatchParams);
-    if (!actionParams)
-        return;
-    let { el, composed } = dispatchParams;
-    let event = new ActionEvent(actionParams, { bubbles: true, composed });
-    el.dispatchEvent(event);
-}
-function getActionParams(dispatchParams) {
-    let { el, sourceEvent, formData } = dispatchParams;
-    let { type } = sourceEvent;
-    let action = el.getAttribute(`${type}:`);
-    if (action)
-        return { action, sourceEvent, formData };
 }

--- a/dist/mod.js
+++ b/dist/mod.js
@@ -34,16 +34,16 @@ export function dispatch(sourceEvent) {
         formData = new FormData(target);
     for (let node of sourceEvent.composedPath()) {
         if (node instanceof Element) {
-            let action = node.getAttribute(`${type}:`);
-            if (!action)
-                continue;
             if (node.hasAttribute(`${type}:prevent-default`))
                 sourceEvent.preventDefault();
             if (node.hasAttribute(`${type}:stop-immediate-propagation`))
                 return;
-            let composed = node.hasAttribute(`${type}:composed`);
-            let event = new ActionEvent({ action, sourceEvent, formData }, { bubbles: true, composed });
-            node.dispatchEvent(event);
+            let action = node.getAttribute(`${type}:`);
+            if (action) {
+                let composed = node.hasAttribute(`${type}:composed`);
+                let event = new ActionEvent({ action, sourceEvent, formData }, { bubbles: true, composed });
+                node.dispatchEvent(event);
+            }
             if (node.hasAttribute(`${type}:stop-propagation`))
                 return;
         }

--- a/examples/counter/index.html
+++ b/examples/counter/index.html
@@ -13,8 +13,8 @@
 		<script type="module" src="./mod.js"></script>
 	</head>
 	<body>
-		<button _click="decrement">-</button>
+		<button click:="decrement">-</button>
 		<span count>42</span>
-		<button _click="increment">+</button>
+		<button click:="increment">+</button>
 	</body>
 </html>

--- a/examples/counter/mod.js
+++ b/examples/counter/mod.js
@@ -1,15 +1,13 @@
-import { SuperAction, SuperActionEvent } from "superaction";
+import { SuperAction } from "superaction";
 const _superAction = new SuperAction({
-    host: document,
+    target: document,
     connected: true,
     eventNames: ["click"],
 });
 const countEl = document.querySelector("[count]");
 let count = parseFloat(countEl.textContent ?? "");
 addEventListener("#action", function (e) {
-    if (!(e instanceof SuperActionEvent))
-        return;
-    let { action } = e;
+    let { action } = e.actionParams;
     if ("increment" === action) {
         count += 1;
     }

--- a/examples/counter/mod.ts
+++ b/examples/counter/mod.ts
@@ -1,7 +1,15 @@
-import { SuperAction, SuperActionEvent } from "superaction";
+import type { ActionEventInterface } from "superaction";
+
+import { SuperAction } from "superaction";
+
+declare global {
+	interface GlobalEventHandlersEventMap {
+		["#action"]: ActionEventInterface;
+	}
+}
 
 const _superAction = new SuperAction({
-	host: document,
+	target: document,
 	connected: true,
 	eventNames: ["click"],
 });
@@ -9,10 +17,8 @@ const _superAction = new SuperAction({
 const countEl = document.querySelector("[count]")!;
 let count = parseFloat(countEl.textContent ?? "");
 
-addEventListener("#action", function (e: Event) {
-	if (!(e instanceof SuperActionEvent)) return;
-
-	let { action } = e;
+addEventListener("#action", function (e) {
+	let { action } = e.actionParams;
 
 	if ("increment" === action) {
 		count += 1;

--- a/examples/sketch/index.html
+++ b/examples/sketch/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html _pointerup="lift_pen" _pointerdown="press_pen" _pointermove="move_pen">
+<html pointerup:="lift_pen" pointerdown:="press_pen" pointermove:="move_pen">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/examples/sketch/index.html
+++ b/examples/sketch/index.html
@@ -41,7 +41,9 @@
 		<script type="module" src="./mod.js"></script>
 	</head>
 	<body>
-		<input type="color" input:="set_color" pointerdown:stop-propagation />
+		<menu>
+			<input type="color" input:="set_color" pointerdown:stop-propagation />
+		</menu>
 		<canvas></canvas>
 	</body>
 </html>

--- a/examples/sketch/index.html
+++ b/examples/sketch/index.html
@@ -41,7 +41,7 @@
 		<script type="module" src="./mod.js"></script>
 	</head>
 	<body>
-		<input type="color" _input="set_color" _pointerdown_stop-propagation />
+		<input type="color" input:="set_color" pointerdown:stop-propagation />
 		<canvas></canvas>
 	</body>
 </html>

--- a/examples/sketch/mod.js
+++ b/examples/sketch/mod.js
@@ -1,6 +1,6 @@
 import { SuperAction } from "superaction";
 const _superAction = new SuperAction({
-    host: document,
+    target: document,
     connected: true,
     eventNames: ["input", "pointerdown", "pointerup", "pointermove"],
 });
@@ -10,7 +10,8 @@ const offscreenCanvas = canvas.transferControlToOffscreen();
 const resizeObserver = new ResizeObserver(sendCanvasParams);
 resizeObserver.observe(canvas);
 addEventListener("#action", function (e) {
-    let { action, target, sourceEvent } = e;
+    let { target } = e;
+    let { action, sourceEvent } = e.actionParams;
     // send actions to the offscreen canvas worker
     if ("set_color" === action) {
         if (target instanceof HTMLInputElement) {

--- a/examples/sketch/mod.ts
+++ b/examples/sketch/mod.ts
@@ -1,13 +1,13 @@
-import { SuperAction, SuperActionEvent } from "superaction";
+import { SuperAction, ActionEventInterface } from "superaction";
 
 declare global {
 	interface GlobalEventHandlersEventMap {
-		["#action"]: SuperActionEvent;
+		["#action"]: ActionEventInterface;
 	}
 }
 
 const _superAction = new SuperAction({
-	host: document,
+	target: document,
 	connected: true,
 	eventNames: ["input", "pointerdown", "pointerup", "pointermove"],
 });
@@ -19,8 +19,9 @@ const offscreenCanvas = canvas.transferControlToOffscreen();
 const resizeObserver = new ResizeObserver(sendCanvasParams);
 resizeObserver.observe(canvas);
 
-addEventListener("#action", function (e: SuperActionEvent) {
-	let { action, target, sourceEvent } = e;
+addEventListener("#action", function (e: ActionEventInterface) {
+	let { target } = e;
+	let { action, sourceEvent } = e.actionParams;
 
 	// send actions to the offscreen canvas worker
 	if ("set_color" === action) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -30,9 +30,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,27 +1,41 @@
-export type {
-	SuperActionParamsInterface,
-	SuperActionEventInterface,
-	SuperActionInterface,
-};
-export { SuperActionEvent, SuperAction };
+export interface ActionInterface {
+	sourceEvent: Event;
+	action: string;
+	formData?: FormData;
+}
 
-interface SuperActionParamsInterface {
-	host: ParentNode;
+export interface ActionEventInterface extends Event {
+	actionParams: ActionInterface;
+}
+
+export interface SuperActionParamsInterface {
+	target: ParentNode;
 	eventNames: string[];
 	connected?: boolean;
 }
 
-interface SuperActionInterface {
+export interface SuperActionInterface {
 	connect(): void;
 	disconnect(): void;
 }
 
-interface SuperActionEventInterface extends Event {
-	action: string;
+interface DispatchParams {
 	sourceEvent: Event;
+	el: Element;
+	composed: boolean;
+	formData?: FormData;
 }
 
-class SuperAction {
+export class ActionEvent extends Event implements ActionEventInterface {
+	actionParams: ActionInterface;
+
+	constructor(actionParams: ActionInterface, eventInit?: EventInit) {
+		super("#action", eventInit);
+		this.actionParams = actionParams;
+	}
+}
+
+export class SuperAction implements SuperActionInterface {
 	#params: SuperActionParamsInterface;
 
 	constructor(params: SuperActionParamsInterface) {
@@ -30,61 +44,67 @@ class SuperAction {
 	}
 
 	connect() {
-		let { host, eventNames } = this.#params;
+		let { target, eventNames } = this.#params;
 		for (let name of eventNames) {
-			host.addEventListener(name, dispatchSuperAction);
+			target.addEventListener(name, dispatch);
 		}
 	}
 
 	disconnect() {
-		let { host, eventNames } = this.#params;
+		let { target, eventNames } = this.#params;
 		for (let name of eventNames) {
-			host.removeEventListener(name, dispatchSuperAction);
+			target.removeEventListener(name, dispatch);
 		}
 	}
 }
 
-class SuperActionEvent extends Event implements SuperActionEvent {
-	#action: string;
-	#sourceEvent: Event;
+export function dispatch(sourceEvent: Event) {
+	let { type, currentTarget, target } = sourceEvent;
+	if (!currentTarget) return;
 
-	constructor(action: string, sourceEvent: Event) {
-		super("#action", { bubbles: true, composed: true });
+	// I forget if a formdata element can be reused but important to find out
+	let formData: FormData | undefined;
+	if (target instanceof HTMLFormElement) formData = new FormData(target);
 
-		this.#action = action;
-		this.#sourceEvent = sourceEvent;
-	}
-
-	get action(): string {
-		return this.#action;
-	}
-
-	get sourceEvent(): Event {
-		return this.#sourceEvent;
-	}
-}
-
-function dispatchSuperAction(e: Event): void {
-	let kind = getEventAttr(e.type);
-	for (let node of e.composedPath()) {
+	for (let node of sourceEvent.composedPath()) {
 		if (node instanceof Element) {
-			let event = getSuperActionEvent(e, kind, node);
-			if (node.hasAttribute(`${kind}_prevent-default`)) e.preventDefault();
-			if (event) node.dispatchEvent(event);
-			if (node.hasAttribute(`${kind}_stop-propagation`)) return;
+			let kind = node.getAttribute(`${type}:`);
+			if (!kind) continue;
+
+			if (node.hasAttribute(`${type}:prevent-default`))
+				sourceEvent.preventDefault();
+
+			if (node.hasAttribute(`${type}:stop-immediate-propagation`)) return;
+
+			let composed = node.hasAttribute(`${type}:composed`);
+			dispatchActionEvent({
+				el: node,
+				sourceEvent,
+				composed,
+				formData,
+			});
+
+			if (node.hasAttribute(`${type}:stop-propagation`)) return;
 		}
 	}
 }
 
-function getEventAttr(eventType: string) {
-	return `_${eventType}`;
+function dispatchActionEvent(dispatchParams: DispatchParams) {
+	let actionParams = getActionParams(dispatchParams);
+	if (!actionParams) return;
+
+	let { el, composed } = dispatchParams;
+
+	let event = new ActionEvent(actionParams, { bubbles: true, composed });
+	el.dispatchEvent(event);
 }
 
-function getSuperActionEvent(
-	e: Event,
-	type: string,
-	el: Element,
-): Event | undefined {
-	let action = el.getAttribute(type);
-	if (action) return new SuperActionEvent(action, e);
+function getActionParams(
+	dispatchParams: DispatchParams,
+): ActionInterface | undefined {
+	let { el, sourceEvent, formData } = dispatchParams;
+	let { type } = sourceEvent;
+
+	let action = el.getAttribute(`${type}:`);
+	if (action) return { action, sourceEvent, formData };
 }

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -60,18 +60,20 @@ export function dispatch(sourceEvent: Event) {
 
 	for (let node of sourceEvent.composedPath()) {
 		if (node instanceof Element) {
-			let action = node.getAttribute(`${type}:`);
-			if (!action) continue;
-
 			if (node.hasAttribute(`${type}:prevent-default`))
 				sourceEvent.preventDefault();
 
 			if (node.hasAttribute(`${type}:stop-immediate-propagation`)) return;
 
-			let composed = node.hasAttribute(`${type}:composed`);
-			
-			let event = new ActionEvent({ action, sourceEvent, formData }, { bubbles: true, composed });
-			node.dispatchEvent(event);
+			let action = node.getAttribute(`${type}:`);
+			if (action) {
+				let composed = node.hasAttribute(`${type}:composed`);
+				let event = new ActionEvent(
+					{ action, sourceEvent, formData },
+					{ bubbles: true, composed },
+				);
+				node.dispatchEvent(event);
+			}
 
 			if (node.hasAttribute(`${type}:stop-propagation`)) return;
 		}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -19,14 +19,6 @@ export interface SuperActionInterface {
 	disconnect(): void;
 }
 
-interface DispatchParams {
-	sourceEvent: Event;
-	el: Element;
-	action: string;
-	composed: boolean;
-	formData?: FormData;
-}
-
 export class ActionEvent extends Event implements ActionEventInterface {
 	actionParams: ActionInterface;
 


### PR DESCRIPTION
HyperEvents is a more full featured concept derived from this humble little repo about event delegation.

Take lessons from hyper events and apply them to SuperAction.

Focusing on action events knocks down build size (1/8 the size of hyper events).
This gives developers a very minimal build (~2kB)

Perfect for people who want action events without remote requests or asynchronous queues and throttles